### PR TITLE
Add a basic implementation of RTCPeerConnection.getLocalStreams

### DIFF
--- a/lib/webrtc/ZombieRTCPeerConnection.js
+++ b/lib/webrtc/ZombieRTCPeerConnection.js
@@ -24,6 +24,7 @@ function ZombieRTCPeerConnection () {
 	this.remoteDescription          = null;
 
 	this._remoteStreams = [];
+	this._localStreams = [];
 
 	var iceConnectionState = "new";
 	Object.defineProperty(this, "iceConnectionState", {
@@ -96,6 +97,12 @@ ZombieRTCPeerConnection.prototype.addIceCandidate = function (candidate, success
 	process.nextTick(successCallback);
 };
 
-ZombieRTCPeerConnection.prototype.addStream = function () {};
+ZombieRTCPeerConnection.prototype.addStream = function (stream) {
+  this._localStreams.push(stream);
+};
+
+ZombieRTCPeerConnection.prototype.getLocalStreams = function () {
+	return _.clone(this._localStreams);
+};
 
 module.exports = ZombieRTCPeerConnection;

--- a/test/webrtc/ZombieRTCPeerConnection_spec.js
+++ b/test/webrtc/ZombieRTCPeerConnection_spec.js
@@ -342,4 +342,17 @@ describe("A ZombieRTCPeerConnection", function () {
 			});
 		});
 	});
+
+  describe("listing local streams", function () {
+    it("should default to an empty list", function () {
+		  var newConnection = new ZombieRTCPeerConnection();
+      expect(newConnection.getLocalStreams()).to.deep.equal([]);
+    });
+    
+    it("should include streams added with addStream", function () {
+		  var newConnection = new ZombieRTCPeerConnection();
+      newConnection.addStream("stream");
+      expect(newConnection.getLocalStreams()).to.deep.equal(["stream"]);
+    });
+  });
 });


### PR DESCRIPTION
This change adds a very simple version of RTCPeerConnection.getLocalStreams and tracks the streams that were added with RTCPeerConnection.addStream