### PR TITLE
Make RTCPeerConnection.setRemoteDescription return a Promise

### DIFF
--- a/lib/webrtc/ZombieRTCPeerConnection.js
+++ b/lib/webrtc/ZombieRTCPeerConnection.js
@@ -3,6 +3,7 @@ var ZombieMediaStreamEvent          = require("./events/ZombieMediaStreamEvent")
 var ZombieRemoteStream              = require("./streams/ZombieRemoteStream");
 var ZombieRTCPeerConnectionIceEvent = require("./events/ZombieRTCPeerConnectionIceEvent");
 var ZombieRTCSessionDescription     = require("./ZombieRTCSessionDescription");
+var Promise                         = require("es6-promise").Promise;
 
 var _ = require("lodash");
 
@@ -90,6 +91,7 @@ ZombieRTCPeerConnection.prototype.setRemoteDescription = function (description, 
 
 	this.remoteDescription = description;
 	process.nextTick(successCallback);
+	return Promise.resolve();
 };
 
 ZombieRTCPeerConnection.prototype.addIceCandidate = function (candidate, successCallback) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "zombie": "^4.0.10"
   },
   "dependencies": {
+    "es6-promise": "^3.2.1",
     "lodash": "^2.4.1",
     "node-uuid": "^1.4.1"
   },

--- a/test/webrtc/ZombieRTCPeerConnection_spec.js
+++ b/test/webrtc/ZombieRTCPeerConnection_spec.js
@@ -225,10 +225,11 @@ describe("A ZombieRTCPeerConnection", function () {
 			var description = "description";
 			var handler     = Sinon.spy();
 			var success     = Sinon.spy();
+			var result      = null;
 
 			before(function (done) {
 				connection.onaddstream = handler;
-				connection.setRemoteDescription(description, success);
+				result = connection.setRemoteDescription(description, success);
 				expect(success.called, "synchronous callback").to.be.false;
 				expect(handler.called, "synchronous handler").to.be.false;
 				process.nextTick(done);
@@ -236,6 +237,14 @@ describe("A ZombieRTCPeerConnection", function () {
 
 			it("sets the description", function () {
 				expect(connection.remoteDescription).to.equal(description);
+			});
+
+			it("returns a Promise that resolves", function () {
+				return result
+					.then(function () {
+						// This is hear to make sure a 'thenable' is returned
+						return;
+					});
 			});
 
 			it("invokes the success callback", function () {
@@ -262,9 +271,10 @@ describe("A ZombieRTCPeerConnection", function () {
 			var connection  = new ZombieRTCPeerConnection();
 			var description = "description";
 			var success     = Sinon.spy();
+			var result      = null;
 
 			before(function (done) {
-				connection.setRemoteDescription(description, success);
+				result = connection.setRemoteDescription(description, success);
 				expect(success.called, "synchronous callback").to.be.false;
 				process.nextTick(done);
 			});
@@ -275,6 +285,14 @@ describe("A ZombieRTCPeerConnection", function () {
 
 			it("sets the description", function () {
 				expect(connection.remoteDescription).to.equal(description);
+			});
+
+			it("returns a Promise that resolves", function () {
+				return result
+					.then(function () {
+						// This is hear to make sure a 'thenable' is returned
+						return;
+					});
 			});
 
 			it("invokes the success callback", function () {


### PR DESCRIPTION
RTCPeerConnection.setRemoteDescription is spec'd to return a Promise and this change implements that feature.  I added a dependency on es6-promise to try avoiding any extra bluebird methods being on the returned Promise (to be as close as possible to what's spec'd)